### PR TITLE
Update for GTK3 fix for gtk_window_set_keep_above

### DIFF
--- a/lib/topify.js
+++ b/lib/topify.js
@@ -77,19 +77,33 @@ function _macTopify(winPtrStr) {
 function _nixTopify(winPtrStr) {
   // TODO: we might need to further transform win before attempting to do this.
   // see https://developer.mozilla.org/en-US/Add-ons/Code_snippets/Finding_Window_Handles#Unix
+  
+  const gdkWin = ostypes.TYPE.GdkWindow.ptr(ctypes.UInt64(winPtrStr));
+  const gtkWin = ostypes.HELPER.gdkWinPtrToGtkWinPtr(gdkWin);
+  ostypes.API.gtk_window_set_keep_above(gtkWin, 1);
+  
+  return true;
+  
+  /*
   let ev = ostypes.TYPE.xcb_client_message_event_t();
   ev.response_type = ostypes.CONST.XCB_CLIENT_MESSAGE;
-  ev.window = ostypes.TYPE.xcb_window_t(ctypes.UInt64(winPtrStr));
+  let gdkWin = ostypes.TYPE.GdkWindow.ptr(ctypes.UInt64(winPtrStr));
+  ev.window = ostypes.HELPER.gdkWinPtrToXID(gdkWin);
   ev.format = 32;
   ev.data.data32[1] = ostypes.CONST.XCB_CURRENT_TIME;
   ev.type = ostypes.HELPER.cachedXCBAtom('_NET_WM_STATE');
   ev.data.data32[0] = ostypes.CONST._NET_WM_STATE_ADD;
   ev.data.data32[1] = ostypes.HELPER.cachedXCBAtom('_NET_WM_STATE_ABOVE');
-  const didSend = ostypes.API('xcb_send_event')(ostypes.HELPER.cachedXCBConn(), 0, ostypes.HELPER.cachedXCBRootWindow(),
+  const didSendCookie = ostypes.API('xcb_send_event_checked')(ostypes.HELPER.cachedXCBConn(), 0, ostypes.HELPER.cachedXCBRootWindow(),
                               ostypes.CONST.XCB_EVENT_MASK_SUBSTRUCTURE_REDIRECT | ostypes.CONST.XCB_EVENT_MASK_SUBSTRUCTURE_NOTIFY,
                               ctypes.cast(ev.address(), ctypes.char.ptr));
+  const didSend = didSendCookieCheck.isNull();
   const didFlush = ostypes.API('xcb_flush')(ostypes.HELPER.cachedXCBConn());
+  
+  ostypes.HELPER.ifOpenedXCBConnClose(); // otherwise mem leak
+  
   return !!didSend;
+  */
 }
 
 module.exports = topify;

--- a/lib/vendor/noitidart-ostypes/ostypes_x11.jsm
+++ b/lib/vendor/noitidart-ostypes/ostypes_x11.jsm
@@ -4417,6 +4417,7 @@ var x11Init = function() {
 		ifOpenedXCBConnClose: function() {
 			if (self._cache.XCBConn) {
 				self.API('xcb_disconnect')(self._cache.XCBConn);
+				delete self._cache.XCBConn;
 			}
 		},
 		cachedAtom: function(aAtomName, createAtomIfDne, refreshCache) {

--- a/lib/vendor/noitidart-ostypes/ostypes_x11.jsm
+++ b/lib/vendor/noitidart-ostypes/ostypes_x11.jsm
@@ -1612,6 +1612,23 @@ var x11Init = function() {
 						libAttempter(path, preferred, possibles);
 
 					break;
+				case 'gtk3':
+
+						var possibles = ['libgtk-3.so.0'];
+
+						var preferred;
+						// all values of preferred MUST exist in possibles reason is link123543939
+						switch (OS_NAME) {
+							case 'linux':
+								preferred = 'libgtk-3.so.0';
+								break;
+							default:
+								// do nothing
+						}
+
+						libAttempter(path, preferred, possibles);
+
+					break;
 				case 'xcb':
 
 						var possibles = ['libxcb.so', 'libxcb.so.1'];
@@ -3030,7 +3047,7 @@ var x11Init = function() {
 			 *   GtkWidget *widget
 			 * );
 			 */
-			return lib('gtk2').declare('gtk_widget_get_window', self.TYPE.ABI,
+			return lib(GTK_VERSION === 2 ? 'gtk2' : 'gtk3').declare('gtk_widget_get_window', self.TYPE.ABI,
 				self.TYPE.GdkWindow.ptr,	// *return
 				self.TYPE.GtkWidget.ptr		// *widget
 			);
@@ -3042,7 +3059,7 @@ var x11Init = function() {
 			 *   gboolean setting
 			 * );
 			 */
-			return lib('gtk2').declare('gtk_window_set_keep_above', self.TYPE.ABI,
+			return lib(GTK_VERSION === 2 ? 'gtk2' : 'gtk3').declare('gtk_window_set_keep_above', self.TYPE.ABI,
 				self.TYPE.void,				// return
 				self.TYPE.GtkWindow.ptr,	// *window
 				self.TYPE.gboolean			// setting
@@ -4631,6 +4648,27 @@ function getGtkVersion() {
 						// anything else to try?
 					}
 				}
+			}
+		}
+
+		if (c_toolkit) {
+			getGtkVersion_cache = c_toolkit.toLowerCase() == 'gtk2' ? 2 : 3;
+		} else {
+			// DO NOT FALL BACK throw, this is critical to get right
+			throw new Error('could not determine gtk version!');
+			// // fallback to guess work based on FIREFOX_VERSION - which is very bad
+			// // guess fall back. this is horrible guess though, as on OpenSuse Firefox 47 is still Gtk2 (TWO) it is NOT gtk THREE
+			// return = FIREFOX_VERSION < 46 ? 2 : 3;
+		}
+	}
+
+	return getGtkVersion_cache;
+
+}
+
+// init
+var ostypes = new x11Init();
+
 			}
 		}
 


### PR DESCRIPTION
This implements GTK3 method (if system is GTK3, else it uses GTK2) so it won't hang. I had to update ostypes_x11.jsm for that.

I also updated the XCB method to work as it should. I commented it out though, so if you want to use XCB you can simply uncomment it, and comment out the GTK stuff above. What I did to the XCB stuff:
- The `gdkWinPtr` is converted to `XID` (which is same as `xcb_window_t`) (I didnt test it, but if js-ctypes complains, the we just have to wrap it in a `ostypes.TYPE.xcb_window_t`)
- It closes the XCB connection, to avoid mem leak. You can move that close connection to addon shutdown though without a problem. (The GTK method doesnt need to close connection.)
- The XCB method was also updated so `didSend` now correctly refelects it.

I couldn't test min vid, but this should work. If it doesn't, please let me know. :)
