### PR TITLE
Fixes #476 - topify behavior

### DIFF
--- a/lib/window-utils.js
+++ b/lib/window-utils.js
@@ -57,7 +57,7 @@ function create() {
   const window = getMostRecentBrowserWindow();
   // implicit assignment to mvWindow global
   mvWindow = window.open(self.data.url('default.html'), 'minvid',
-                         'chrome,dialog=no,width=320,height=180,titlebar=no,alwaysRaised');
+                         'chrome,dialog=no,width=320,height=180,titlebar=no');
   // once the window's ready, make it always topmost
   whenReady(() => { topify(mvWindow); });
   initCommunication();


### PR DESCRIPTION
Fixes https://github.com/meandavejustice/min-vid/issues/476

The `alwaysRaised` flag does nothing good. Should never be used. It only does something (something bad) on Windows.

We'll need to revert - 98591a432c697c58885554a6aa9f021ffae903eb - the change to bring back `HWND_TOPMOST` please.